### PR TITLE
Fix old bitbucket URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "A project with Grunt and entwine preconfigured for most purposes.",
   "main": "index.js",
   "repository": {
-    "type": "hg",
-    "url": "https://bitbucket.org/klembot/grunt-entwine-quickstart"
+    "type": "git",
+    "url": "https://github.com/klembot/grunt-entwine-quickstart.git"
   },
   "author": "Chris Klimas <chris@twinery.org> (https://twinery.org)",
   "license": "CC0-1.0",
-  "homepage": "https://bitbucket.org/klembot/grunt-entwine-quickstart#readme",
+  "homepage": "https://github.com/klembot/grunt-entwine-quickstart#readme",
   "dependencies": {
     "download-file": "^0.1.5",
     "filenamify": "^1.2.1",


### PR DESCRIPTION
This is self explanatory.

It should be noted I did not test this at all but I doubt it breaks anything--at least not more than it was already broken.